### PR TITLE
Remove Devolutions viewer dependencies

### DIFF
--- a/ControlR.Viewer.Avalonia/ControlR.Viewer.Avalonia.csproj
+++ b/ControlR.Viewer.Avalonia/ControlR.Viewer.Avalonia.csproj
@@ -23,10 +23,9 @@
     <PackageReference Include="Bitbound.SimpleMessenger" />
     <PackageReference Include="CommunityToolkit.Diagnostics" />
     <PackageReference Include="CommunityToolkit.Mvvm" />
-    <PackageReference Include="Devolutions.AvaloniaControls" />
-    <PackageReference Include="Devolutions.AvaloniaTheme.DevExpress" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="SkiaSharp" />
+    <PackageReference Include="System.Reactive" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ControlR.ApiClient\ControlR.ApiClient.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,10 +23,7 @@
     <PackageVersion Include="ControlR.ApiClient" Version="0.23.17" />
     <PackageVersion Include="ControlR.Viewer.Avalonia" Version="0.23.17" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="Devolutions.AvaloniaControls" Version="2026.7.6" />
     <PackageVersion Include="Devolutions.AvaloniaTheme.DevExpress" Version="2026.7.6" />
-    <PackageVersion Include="Devolutions.AvaloniaTheme.Linux" Version="2026.7.6" />
-    <PackageVersion Include="Devolutions.AvaloniaTheme.MacOS" Version="2026.7.6" />
     <PackageVersion Include="Devolutions.Cadeau" Version="2026.6.18" />
     <PackageVersion Include="Extensions.MudBlazor.StaticInput" Version="4.1.0" />
     <PackageVersion Include="HotAvalonia" Version="3.1.3" />
@@ -111,6 +108,7 @@
     <PackageVersion Include="System.Drawing.Common" Version="10.0.9" />
     <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.Net.Http.Json" Version="10.0.3" />
+    <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.9" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
     <!-- Avalonia has transient dependencies built against this version of Tmds.DBus. -->

--- a/Examples/ControlR.AvaloniaViewerExample/ControlR.AvaloniaViewerExample.csproj
+++ b/Examples/ControlR.AvaloniaViewerExample/ControlR.AvaloniaViewerExample.csproj
@@ -23,6 +23,7 @@
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="Devolutions.AvaloniaTheme.DevExpress" />
     <PackageReference Include="HotAvalonia" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />


### PR DESCRIPTION
## Summary
- remove unused Devolutions controls and theme dependencies from `ControlR.Viewer.Avalonia`
- retain the DevExpress theme as an explicit dependency of the sample app that uses it
- add an explicit `System.Reactive` dependency required by the viewer implementation

## Validation
- built `ControlR.Viewer.Avalonia` and `ControlR.AvaloniaViewerExample`
- inspected the generated `ControlR.Viewer.Avalonia` package metadata to confirm it contains neither Devolutions dependency